### PR TITLE
remove 'generalities' rename for ghost blocks

### DIFF
--- a/scripts/NEI.zs
+++ b/scripts/NEI.zs
@@ -428,7 +428,8 @@ NEI.addEntry(<minecraft:chest>.withTag({display: {Name: "Chest", Lore: ["Storage
 <CarpentersBlocks:blockCarpentersBlock>.displayName = "Wooden Construction Frame";
 <minecraft:iron_ingot>.displayName = "Refined Iron";
 <minecraft:quartz_block>.displayName = "Albino Block of Jet";
-<Eln:Eln.ghostBlock>.displayName = "EA Block of Generalities in Purpose";
+// disabled this because the name contaminates other ghost blocks
+//<Eln:Eln.ghostBlock>.displayName = "EA Block of Generalities in Purpose";
 <minecraft:gold_ingot>.displayName = "Refined Gold";
 <BuildCraft|Core:diamondGearItem>.displayName = "Blue Steel Gear";
 


### PR DESCRIPTION
This removes the rename of ELN's ghost block to "EA Block of Generalities in Purpose"

...it was a cute rename, but the tag was matching on most all of the ghost blocks, resulting in hundreds of very non-ELN-related things being tagged as such.
